### PR TITLE
Remove old argument for vMF distribution

### DIFF
--- a/main_mlp.py
+++ b/main_mlp.py
@@ -62,12 +62,6 @@ def parse_args():
         default=10,
         help="Number of batches to average evaluation performance at the end.",
     )
-    parser.add_argument(
-        "--rej-mult",
-        type=float,
-        default=1,
-        help="Memory/CPU trade-off factor for rejection resampling.",
-    )
     parser.add_argument("--seed", type=int, default=None)
     parser.add_argument(
         "--act-fct",
@@ -191,8 +185,7 @@ def main():
     else:
         sample_conditional = (
             lambda space, z, size, device=device: space.von_mises_fisher(
-                z, args.c_param, size, device, rejection_multiplier=args.rej_mult
-            )
+                z, args.c_param, size, device)
         )
     latent_space = latent_spaces.LatentSpace(
         space=space,


### PR DESCRIPTION
remove old argument, currently errors out if vmf is used since a change in the arguments the underlying function expects